### PR TITLE
Adjust binary paths

### DIFF
--- a/sync/variables.yaml
+++ b/sync/variables.yaml
@@ -1,3 +1,3 @@
 --- 
-kubelet_path:  "./sync/kubelet" 
-kubeproxy_path:  "~/home/sladyn/work/src/k8s.io/kubernetes/_output/bin/kube-proxy.exe" 
+kubelet_path:  "./sync/bin/kubelet.exe"
+kubeproxy_path:  "./sync/bin/kube-proxy.exe"


### PR DESCRIPTION
These got added but didn't use the expected output paths for
everyone. Assume these should be using the binaries that
were just built.