### PR TITLE
Add lite mode for less RAM/CPUs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 require 'yaml'
 
 # Modify these in the variables.yaml file... they are described there in gory detail...
-settings = YAML.load_file 'sync/shared/variables.yaml'
+settingsFile = ENV["VAGRANT_VARIABLES"] || 'sync/shared/variables.yaml'
+settings = YAML.load_file settingsFile
 k8s_linux_registry=settings['k8s_linux_registry']
 k8s_linux_kubelet_deb=settings['k8s_linux_kubelet_deb']
 k8s_linux_apiserver=settings['k8s_linux_apiserver']
@@ -11,6 +12,12 @@ kubernetes_version_windows=settings['kubernetes_version_windows']
 
 overwrite_linux_bins = settings['overwrite_linux_bins']
 overwrite_windows_bins = settings['overwrite_windows_bins'] ? "-OverwriteBins" : ""
+
+linux_ram = settings['linux_ram']
+linux_cpus = settings['linux_cpus']
+windows_ram = settings['windows_ram']
+windows_cpus = settings['windows_cpus']
+
 
 Vagrant.configure(2) do |config|
 
@@ -24,8 +31,8 @@ Vagrant.configure(2) do |config|
     controlplane.vm.provider :virtualbox do |vb|
     controlplane.vm.synced_folder "./sync/shared", "/var/sync/shared"
     controlplane.vm.synced_folder "./sync/linux", "/var/sync/linux"
-      vb.memory = 8192
-      vb.cpus = 4
+      vb.memory = linux_ram
+      vb.cpus = linux_cpus
     end
     controlplane.vm.provision :shell, privileged: false, path: "sync/linux/controlplane.sh", args: "#{overwrite_linux_bins} #{k8s_linux_registry} #{k8s_linux_kubelet_deb} #{k8s_linux_apiserver} "
   end
@@ -39,8 +46,8 @@ Vagrant.configure(2) do |config|
     winw1.vm.synced_folder "./sync/shared", "C:\\sync\\shared"
     winw1.vm.synced_folder "./sync/windows", "C:\\sync\\windows"
     winw1.vm.provider :virtualbox do |vb|
-      vb.memory = 8192
-      vb.cpus = 4
+      vb.memory = windows_ram
+      vb.cpus = windows_cpus
       vb.gui = false
     end
 

--- a/sync/shared/kubejoin.ps1
+++ b/sync/shared/kubejoin.ps1
@@ -1,3 +1,3 @@
 $env:path += ";C:\Program Files\containerd"
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
-kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token v3seop.mso4p1ibifs87ucp --discovery-token-ca-cert-hash sha256:2dea5736a807dc50b09c67c4c0da2f66f30111cd379af31b172b7aa2482a479a 
+kubeadm join 10.20.30.10:6443 --cri-socket "npipe:////./pipe/containerd-containerd" --token 9ehroj.ymupqnfk6lmsi9mc --discovery-token-ca-cert-hash sha256:6c339766d490a41c79977e77c60e9a022b9b8aceacfa4c817cc8dd6c0fbd3c1d 

--- a/sync/shared/variables-lite.yaml
+++ b/sync/shared/variables-lite.yaml
@@ -24,7 +24,7 @@ kubernetes_version_windows:  "1.21.0"
 overwrite_linux_bins: false
 overwrite_windows_bins: false
 
-linux_ram: 4096
-linux_cpus: 4
-windows_ram: 8162
-windows_cpus: 4
+linux_ram: 2048
+linux_cpus: 2
+windows_ram: 4096
+windows_cpus: 2


### PR DESCRIPTION
I am on a device with 16GB RAM and unable
to run as configured. Thats difficult to work with
since I'm constantly stashing/popping changes to the
vagrantfile if I'm also trying to stay up to date
with the latest version.

This allows me to just set an env var and dev
as anyone else would.

Signed-off-by: John Schnake <jschnake@vmware.com>