### PR TITLE
Force checkout of k8s

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -34,7 +34,7 @@ fi
 if [[ -d "kubernetes" ]] ; then
   echo "kubernetes/ exists, not cloning..."
   pushd kubernetes
-    git checkout $kubernetes_sha
+    git checkout $kubernetes_sha -f
   popd
 else
   git clone https://github.com/kubernetes/kubernetes.git


### PR DESCRIPTION
To avoid re-cloning all of k8s I usually copy over
my repo from my normal path. But when I do that and am
on `master` I get warnings when trying to checkout the
given sha.

Since this is a kubernetes folder just for this project,
it seems reasonable to me to add the `-f` checkout and
discard local changes if they exist.

Signed-off-by: John Schnake <jschnake@vmware.com>